### PR TITLE
Cross-platform method of getting an RFC-2822 date string 

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -16,9 +16,11 @@ import sys
 import os
 
 # create up2date gitversion file (which is included at the top)
+from email.Utils import formatdate
 from subprocess import check_output
 repo_version = check_output("git describe --always --tags --dirty | tee gitversion.rst_tochide", shell=True)
-check_output(r'echo "(`date -Ru`)" >> gitversion.rst_tochide', shell=True)
+with open("gitversion.rst_tochide", mode="a") as fp:
+    fp.write(formatdate(localtime=False, usegmt=True))
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the


### PR DESCRIPTION
(the `date` command doesn't have the `-R` flag on OS X)