### PR TITLE
Change deafault to gmax_div=2

### DIFF
--- a/pm/examples/hw/nmpm1_single_neuron.py
+++ b/pm/examples/hw/nmpm1_single_neuron.py
@@ -97,7 +97,7 @@ def set_sthal_params(wafer, gmax, gmax_div):
     """
     synaptic strength:
     gmax: 0 - 1023, strongest: 1023
-    gmax_div: 1 - 15, strongest: 1
+    gmax_div: 2 - 15, strongest: 1
     """
 
     # for all HICANNs in use
@@ -131,7 +131,7 @@ def set_sthal_params(wafer, gmax, gmax_div):
             fgs.setShared(block, HICANN.shared_parameter.V_ccas, 800)
 
 # call at least once
-set_sthal_params(runtime.wafer(), gmax=1023, gmax_div=1)
+set_sthal_params(runtime.wafer(), gmax=1023, gmax_div=2)
 
 #  ——— configure hardware ——————————————————————————————————————————————————————
 

--- a/pm/examples/hw/nmpm1_sweep_fg.py
+++ b/pm/examples/hw/nmpm1_sweep_fg.py
@@ -97,7 +97,7 @@ def set_sthal_params(wafer, gmax, gmax_div):
     """
     synaptic strength:
     gmax: 0 - 1023, strongest: 1023
-    gmax_div: 1 - 15, strongest: 1
+    gmax_div: 2 - 15, strongest: 1
     """
 
     # for all HICANNs in use
@@ -131,7 +131,7 @@ def set_sthal_params(wafer, gmax, gmax_div):
             fgs.setShared(block, HICANN.shared_parameter.V_ccas, 800)
 
 # call at least once
-set_sthal_params(runtime.wafer(), gmax=1023, gmax_div=1)
+set_sthal_params(runtime.wafer(), gmax=1023, gmax_div=2)
 
 #  ——— configure hardware ——————————————————————————————————————————————————————
 

--- a/pm/examples/hw/nmpm1_sweep_spike_times.py
+++ b/pm/examples/hw/nmpm1_sweep_spike_times.py
@@ -79,7 +79,7 @@ def set_sthal_params(wafer, gmax, gmax_div):
     """
     synaptic strength:
     gmax: 0 - 1023, strongest: 1023
-    gmax_div: 1 - 15, strongest: 1
+    gmax_div: 2 - 15, strongest: 1
     """
 
     # for all HICANNs in use
@@ -113,7 +113,7 @@ def set_sthal_params(wafer, gmax, gmax_div):
             fgs.setShared(block, HICANN.shared_parameter.V_ccas, 800)
 
 # call at least once
-set_sthal_params(runtime.wafer(), gmax=1023, gmax_div=1)
+set_sthal_params(runtime.wafer(), gmax=1023, gmax_div=2)
 
 #  ——— configure hardware ——————————————————————————————————————————————————————
 

--- a/pm/pm_hardware_configuration.rst
+++ b/pm/pm_hardware_configuration.rst
@@ -78,7 +78,7 @@ The synaptic weight of a single synapse is proportional to the synaptic current 
 .. math::
    I_{syn} \propto w \cdot \frac{V_{gmax}}{gmax\_div},
 
-where :math:`w \in [0, 15]` is the 4-bit weight in every synapse, :math:`gmax\_div \in [0, 30]` can be set per synapse row and :math:`V_{gmax} \in [0, 1023]` can be selected per synapse row from one of four values per HICANN quadrant.
+where :math:`w \in [0, 15]` is the 4-bit weight in every synapse, :math:`gmax\_div \in [2, 30]` can be set per synapse row and :math:`V_{gmax} \in [0, 1023]` can be selected per synapse row from one of four values per HICANN quadrant.
 
 The synaptic conductance course is then generated according to the configured synaptic time constant within the synaptic input circuit of a neuron.
 


### PR DESCRIPTION
In the current state of the software stack, gmax_div=1 can lead to silent errors.
Also change the range of gmax_div from [1,.. to [2,.. in docstring ad docu.